### PR TITLE
Add ALLOW_REMOTE_BACKEND env var in webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,19 +139,20 @@ The application consists of two parts:
 The frontend connects to the backend via Server-Sent Events (SSE) at `/api/updates`. 
 
 **Dynamic Backend URL:**
-- The frontend includes a backend URL input field in the header
+- The frontend includes a backend URL input field in the header (development builds only)
 - Users can connect to any backend instance by entering the URL
 - Supports both local and remote backend instances
 - Shows connection status (connected/disconnected)
 - Defaults to `http://localhost:8080` in development
 
 **Query Parameter Configuration:**
-- You can also set the backend URL via query parameter: `?backend_url=http://your-backend:8080`
+- You can set the backend URL via query parameter: `?backend_url=http://your-backend:8080`
 - Examples:
   - `http://localhost:3000?backend_url=http://192.168.1.100:8080`
   - `http://localhost:3000?backend_url=https://api.yourdomain.com`
 - Query parameter takes precedence over defaults but can still be overridden via the UI input field
 - Useful for direct links to specific backend instances or automated testing
+- Only available in development builds
 
 **Development Setup:**
 - Uses `webpack.dev.js` configuration
@@ -166,15 +167,28 @@ ports:
 
 **Production Setup:**
 - Uses `webpack.prod.js` configuration
-- Frontend uses relative URLs (e.g., `/api/updates`) by default
-- Users can still connect to remote backends via the URL input
+- Frontend uses relative URLs (e.g., `/api/updates`) 
+- Backend URL input field is hidden
 - Build with: `yarn build` or `npm run build`
 
 **Usage:**
-1. Click the backend URL field in the header
+1. Click the backend URL field in the header (development only)
 2. Enter the backend URL (e.g., `localhost:8080`, `api.yourdomain.com`, `192.168.1.100:8080`)
 3. Click "Connect" to establish the connection
 4. The connection status will show green (connected) or red (disconnected)
+
+### Frontend Build Configuration
+
+The frontend uses the `ALLOW_REMOTE_BACKEND` environment variable to control backend URL configuration:
+
+- **Development builds**: `ALLOW_REMOTE_BACKEND=true` (set in `webpack.dev.js`)
+  - Backend URL input field is visible
+  - Query parameter backend URL works
+  
+- **Production builds**: `ALLOW_REMOTE_BACKEND=false` (set in `webpack.prod.js`)
+  - Backend URL input field is hidden
+  - Query parameter backend URL is disabled
+  - Uses relative URLs only
 
 ## Available Commands
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,11 +36,13 @@ function App() {
           <h1>Asset Hub Migration Monitor</h1>
         </div>
         <div className="header-info">
-          <BackendUrlInput
-            currentUrl={backendUrl}
-            onUrlChange={handleBackendUrlChange}
-            isConnected={isConnected}
-          />
+          {process.env.ALLOW_REMOTE_BACKEND === 'true' && (
+            <BackendUrlInput
+              currentUrl={backendUrl}
+              onUrlChange={handleBackendUrlChange}
+              isConnected={isConnected}
+            />
+          )}
           <span className="timestamp">Last updated: {new Date().toLocaleString()}</span>
           <div className="finalized-heads">
             <div className="head-display">

--- a/frontend/src/hooks/useEventSource.tsx
+++ b/frontend/src/hooks/useEventSource.tsx
@@ -18,9 +18,14 @@ interface EventSourceProviderProps {
   initialBackendUrl?: string;
 }
 
-// Get initial backend URL - checks query param first, then defaults
+// Get initial backend URL - compile-time security check
 const getInitialBackendUrl = () => {
-  // Check for query parameter first
+  // Compile-time check: if remote backends are disabled, always use relative URLs
+  if (process.env.ALLOW_REMOTE_BACKEND !== 'true') {
+    return '';
+  }
+  
+  // Development mode: check for query parameter first
   const urlParams = new URLSearchParams(window.location.search);
   const backendUrlParam = urlParams.get('backend_url');
   
@@ -28,12 +33,8 @@ const getInitialBackendUrl = () => {
     return backendUrlParam;
   }
   
-  // Existing fallback logic
-  if (process.env.NODE_ENV === 'development') {
-    return 'http://localhost:8080';
-  }
-  // In production, use relative URL by default
-  return '';
+  // Development fallback
+  return 'http://localhost:8080';
 };
 
 export const EventSourceProvider: React.FC<EventSourceProviderProps> = ({ 
@@ -147,6 +148,12 @@ export const EventSourceProvider: React.FC<EventSourceProviderProps> = ({
   }, [backendUrl, createEventSource, clearReconnectTimeout]);
 
   const setBackendUrl = useCallback((url: string) => {
+    // Compile-time check: prevent changing backend URL when remote backends are disabled
+    if (process.env.ALLOW_REMOTE_BACKEND !== 'true') {
+      console.warn('Backend URL changes are disabled for security reasons');
+      return;
+    }
+    
     // Clear any pending reconnection attempts when URL changes
     clearReconnectTimeout();
     reconnectAttemptsRef.current = 0;

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -53,6 +53,7 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('development'),
+      'process.env.ALLOW_REMOTE_BACKEND': JSON.stringify('true'),
     }),
   ],
   devServer: {

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -54,6 +54,7 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
+      'process.env.ALLOW_REMOTE_BACKEND': JSON.stringify('false'),
     }),
   ],
   optimization: {


### PR DESCRIPTION
  Removes dynamic backend URL configuration from production builds.

  Changes:
  - Added ALLOW_REMOTE_BACKEND compile-time environment variable
  - Production builds: Backend URL input hidden, query parameters disabled, uses relative URLs only
  - Development builds: Full functionality preserved
  - Webpack dead code elimination removes vulnerable code paths from production bundles
  