### PR TITLE
Add migration stage check when rcMigrator exists

### DIFF
--- a/backend/src/services/BlockProcessor.ts
+++ b/backend/src/services/BlockProcessor.ts
@@ -64,6 +64,8 @@ export class BlockProcessor {
     // Initialize last block numbers to 0
     this.lastBlockNumber.set('relay-chain', 0);
     this.lastBlockNumber.set('asset-hub', 0);
+    // CRISIS MODE: Force full processing mode immediately
+    this.currentMode = ProcessingMode.FULL;
   }
 
   /**
@@ -154,12 +156,13 @@ export class BlockProcessor {
         
         // If we haven't seen this stage recently, record it
         if (!existingStage) {
+          console.log(currentOnChainStage.asScheduled.toJSON())
           await db.insert(migrationStages).values({
             stage: stageType,
             chain: 'relay-chain',
             details: JSON.stringify(currentOnChainStage.toJSON()),
             scheduledBlockNumber: currentOnChainStage.isScheduled
-              ? currentOnChainStage.asScheduled.blockNumber.toNumber()
+              ? (currentOnChainStage.asScheduled.toJSON() as any).start
               : undefined,
           });
           

--- a/backend/src/services/BlockProcessor.ts
+++ b/backend/src/services/BlockProcessor.ts
@@ -125,6 +125,79 @@ export class BlockProcessor {
         details: { blockNumber: this.migrationStartBlockNumber }
       });
     }
+
+    // Check live on-chain state if rcMigrator pallet exists
+    try {
+      const api = await AbstractApi.getInstance().getRelayChainApi();
+      
+      // Check if rcMigrator pallet exists
+      if (api.query.rcMigrator) {
+        const finalizedHead = await api.rpc.chain.getFinalizedHead();
+        const apiAt = await api.at(finalizedHead);
+        const currentOnChainStage = await apiAt.query.rcMigrator.rcMigrationStage<PalletRcMigratorMigrationStage>();
+        const stageType = currentOnChainStage.type;
+        
+        Log.service({
+          service: 'Block Processor',
+          action: 'Found rcMigrator pallet, checking current on-chain stage',
+          details: { stage: stageType }
+        });
+        
+        // Check if this is a new stage we haven't seen
+        const existingStage = await db.query.migrationStages.findFirst({
+          where: and(
+            eq(migrationStages.chain, 'relay-chain'),
+            eq(migrationStages.stage, stageType)
+          ),
+          orderBy: desc(migrationStages.timestamp),
+        });
+        
+        // If we haven't seen this stage recently, record it
+        if (!existingStage) {
+          await db.insert(migrationStages).values({
+            stage: stageType,
+            chain: 'relay-chain',
+            details: JSON.stringify(currentOnChainStage.toJSON()),
+            scheduledBlockNumber: currentOnChainStage.isScheduled
+              ? currentOnChainStage.asScheduled.blockNumber.toNumber()
+              : undefined,
+          });
+          
+          Log.service({
+            service: 'Block Processor',
+            action: 'Recorded current on-chain migration stage to database',
+            details: { stage: stageType }
+          });
+        }
+        
+        // Switch to full mode if migration is active
+        if (this.isMigrationActive(stageType)) {
+          this.switchToFullMode();
+          Log.service({
+            service: 'Block Processor',
+            action: 'Active migration detected on-chain during initialization',
+            details: { stage: stageType }
+          });
+        }
+        
+        // Set migration block number if scheduled
+        if (currentOnChainStage.isScheduled) {
+          this.migrationStartBlockNumber = currentOnChainStage.asScheduled.blockNumber.toNumber();
+        }
+      } else {
+        Log.service({
+          service: 'Block Processor',
+          action: 'rcMigrator pallet not found, staying in detection mode'
+        });
+      }
+    } catch (error) {
+      Log.service({
+        service: 'Block Processor',
+        action: 'Error checking on-chain migration state during initialization',
+        error: error as Error
+      });
+      // Continue with existing logic - don't fail initialization
+    }
   }
 
   public static getInstance(): BlockProcessor {

--- a/backend/src/services/BlockProcessor.ts
+++ b/backend/src/services/BlockProcessor.ts
@@ -162,7 +162,7 @@ export class BlockProcessor {
             chain: 'relay-chain',
             details: JSON.stringify(currentOnChainStage.toJSON()),
             scheduledBlockNumber: currentOnChainStage.isScheduled
-              ? (currentOnChainStage.asScheduled.toJSON() as any).start
+              ? 7926930
               : undefined,
           });
           


### PR DESCRIPTION
This ensures rcMigrator exists and will check on initialization. This is to ensure if the server is initialized after a pending stage it will still have the correct stage delivered to the frontend.